### PR TITLE
Add profile history export workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 venv/
 env/
 *.egg-info/
+browsers/
+runtime/
 
 # 若在仓库根目录生成本地抓取目录（默认多在 ~/.openclaw/workspace/）
 zhihu_articles_*/

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Cookie 经常失效，想要**持久化上下文 + 保活**？
 | 能力 | 说明 |
 |------|------|
 | 收藏夹列表 | `fetch_zhihu_collection.py` 优先 API，失败降级 Playwright DOM；输出 JSON 列表 |
-| 批量抓取 | `fetch_zhihu_batch.py`：正文 Markdown、图片默认写入 `{输出目录}/images/`、`_progress.json` 断点续传 |
+| 个人历史列表 | `fetch_zhihu_history.py`：个人主页点赞/收藏动态，支持时间范围、断点续跑、互动时间元数据 |
+| 批量抓取 | `fetch_zhihu_batch.py`：正文 Markdown、图片默认写入 `{输出目录}/images/`、`_progress.json` 断点续传、失败自动重试、API 回退 |
 | Cookie | 持久化浏览器上下文 + 定时保活；失效时用 `zhihu_relogin.py` 手动登录 |
 | 单篇 / 调试 | `fetch_zhihu.py`、`fetch_zhihu_api.py`、`fetch_zhihu_stealth.py`、`fetch_zhihu_interactive.py` 等多路径 |
-| Obsidian | `write_to_obsidian.py`：Vault 检测、按内容与已有「知乎收藏」结构智能分类、同步图片 |
+| Obsidian | `write_to_obsidian.py`：Vault 检测、按内容与已有「知乎收藏」结构智能分类、同步图片；`write_zhihu_history_to_obsidian.py` 支持历史项 URL 去重导入 |
 
 **依赖**：见 [`scripts/requirements.txt`](scripts/requirements.txt)，并需 `playwright install chromium`。
 
@@ -77,6 +78,28 @@ python scripts/fetch_zhihu_batch.py <列表.json>
 python scripts/write_to_obsidian.py <文章目录> [Vault路径]
 ```
 
+个人历史（点赞 / 收藏）示例：
+
+```bash
+# 1. 个人动态 → JSON 列表（起始时间含，结束时间不含）
+python scripts/fetch_zhihu_history.py \
+  https://www.zhihu.com/people/<slug> \
+  2026-01-01T00:00:00+01:00 \
+  runtime/zhihu_history_2026-01-01_to_2026-04-05.json \
+  --until 2026-04-05T00:00:00+02:00
+
+# 2. 批量抓取正文与图片（失败默认自动重试 3 次）
+python scripts/fetch_zhihu_batch.py \
+  runtime/zhihu_history_2026-01-01_to_2026-04-05.json \
+  runtime/zhihu_articles_history_2026-01-01_to_2026-04-05
+
+# 3. 写入 Obsidian 的「知乎收藏/{分类}/」根分类文件夹，按 url 去重更新
+python scripts/write_zhihu_history_to_obsidian.py \
+  runtime/zhihu_articles_history_2026-01-01_to_2026-04-05 \
+  /path/to/ObsidianVault \
+  .
+```
+
 Cookie 异常时：
 
 ```bash
@@ -101,12 +124,15 @@ zhihu-fetch-skill/
 └── scripts/
     ├── requirements.txt
     ├── fetch_zhihu_collection.py
+    ├── fetch_zhihu_history.py
     ├── fetch_zhihu_batch.py
     ├── fetch_zhihu.py
     ├── fetch_zhihu_api.py
     ├── fetch_zhihu_stealth.py
     ├── fetch_zhihu_interactive.py
     ├── write_to_obsidian.py
+    ├── write_zhihu_history_to_obsidian.py
+    ├── write_zhihu_failures.py
     ├── zhihu_login.py
     ├── zhihu_login_save.py
     └── zhihu_relogin.py

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,8 +50,11 @@ allowed-tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch
 | 任务 | 建议方式 |
 |------|----------|
 | 获取收藏夹 JSON 列表 | **`Bash`** → `python "${CLAUDE_SKILL_DIR}/scripts/fetch_zhihu_collection.py" <收藏夹URL或ID>`；优先 API，失败降级 Playwright DOM |
+| 获取个人主页点赞/收藏历史 | **`Bash`** → `python "${CLAUDE_SKILL_DIR}/scripts/fetch_zhihu_history.py" <people URL 或 slug> <起始时间ISO> <输出.json> [--until <结束时间ISO>]`；按活动时间保留 `interaction_*` 元数据，支持断点续跑 |
 | 批量抓取正文与图片 | **`Bash`** → `python "${CLAUDE_SKILL_DIR}/scripts/fetch_zhihu_batch.py" <列表.json> [输出目录] [图片目录]`；默认输出目录见「路径约定」 |
 | 写入 Obsidian Vault | **`Bash`** → `python "${CLAUDE_SKILL_DIR}/scripts/write_to_obsidian.py" <文章目录> [Vault路径]`；Vault：命令行优先，否则环境变量 **`OBSIDIAN_VAULT`**；会先找 `<文章目录>/images`，否则兼容同级 **`zhihu_images`** |
+| 写入个人历史到 Obsidian | **`Bash`** → `python "${CLAUDE_SKILL_DIR}/scripts/write_zhihu_history_to_obsidian.py" <文章目录> <Vault路径> [.]`；默认写入 `{Vault}/知乎收藏/{分类}/`，按 URL 去重更新 |
+| 写入失败项清单 | **`Bash`** → `python "${CLAUDE_SKILL_DIR}/scripts/write_zhihu_failures.py" <Vault路径> <标签>:<progress.json> ...`；生成 `{Vault}/知乎收藏/抓取失败.md` |
 | Cookie 失效需人工登录 | **`Bash`** → `python "${CLAUDE_SKILL_DIR}/scripts/zhihu_relogin.py"`（会打开浏览器窗口） |
 | 首次登录辅助（可选验证页） | **`Bash`** → `zhihu_login.py`；可选 **`ZHIHU_VERIFY_URL`** 或首个参数传入完整 http(s) 链接，见「登录与可选页面验证」 |
 | 单篇快速验证 | **`Bash`** → `fetch_zhihu_api.py` / `fetch_zhihu_stealth.py` / `fetch_zhihu_interactive.py` / 汇总 **`fetch_zhihu.py`**（自动多策略），按场景选用 |
@@ -64,12 +67,15 @@ allowed-tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch
 | 脚本 | 用途 | 典型场景 |
 |------|------|----------|
 | `fetch_zhihu_collection.py` | **收藏夹列表**，智能版 | 输出 `zhihu_collection_{id}.json` |
-| `fetch_zhihu_batch.py` | **批量抓取**，推荐 | 大量文章、图片、`images/`、`_progress.json` |
+| `fetch_zhihu_history.py` | **个人历史列表** | 点赞/收藏动态，支持 `--until`、`--fresh`、断点续跑 |
+| `fetch_zhihu_batch.py` | **批量抓取**，推荐 | 大量文章、图片、`images/`、`_progress.json`，失败自动重试，DOM 不足时 API 回退 |
 | `fetch_zhihu.py` | 自动降级抓取 | 单篇、多策略串联 |
 | `fetch_zhihu_api.py` | API 直连 | 快速测试 |
 | `fetch_zhihu_stealth.py` | Playwright 隐身 | 绕过常见自动化检测 |
 | `fetch_zhihu_interactive.py` | 交互式浏览器 | 登录页、验证码 |
 | `write_to_obsidian.py` | 写入 Obsidian | 自动检测 Vault、智能分类、`知乎收藏/` |
+| `write_zhihu_history_to_obsidian.py` | 写入个人历史到 Obsidian | 保留互动时间、动作标签、按 URL 去重 |
+| `write_zhihu_failures.py` | 写入失败项清单 | 生成 `抓取失败.md` 方便人工重试 |
 | `zhihu_relogin.py` | 重新登录 | Cookie 不可用 |
 | `zhihu_login.py` | 登录辅助 | 检测 `z_c0`；可选访问 **`ZHIHU_VERIFY_URL`** / 命令行 URL 做页面级验证 |
 | `zhihu_login_save.py` | 登录并保存 | 按需配合 Cookie 流程 |
@@ -84,6 +90,41 @@ allowed-tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch
 4. （可选）**`write_to_obsidian.py`** → 同步到 **`{Vault}/知乎收藏/{分类}/`**。
 
 中断批量任务时：**重新运行同一条** `fetch_zhihu_batch.py` 命令即可续跑（已完成 URL 记录在 `_progress.json`）。
+
+### 个人历史流程（点赞 / 收藏）
+
+适用于个人主页动态中的 **赞同了回答 / 赞同了文章 / 收藏了回答 / 收藏了文章**。时间采用 ISO 格式；若时间无时区，脚本默认按 **Europe/Stockholm** 解释。
+
+```bash
+# 1. 收集活动列表（起始时间含，结束时间不含）
+python scripts/fetch_zhihu_history.py \
+  https://www.zhihu.com/people/<slug> \
+  2026-01-01T00:00:00+01:00 \
+  /path/to/runtime/zhihu_history_2026-01-01_to_2026-04-05.json \
+  --until 2026-04-05T00:00:00+02:00
+
+# 2. 抓取正文与图片；失败默认自动重试 3 次
+python scripts/fetch_zhihu_batch.py \
+  /path/to/runtime/zhihu_history_2026-01-01_to_2026-04-05.json \
+  /path/to/runtime/zhihu_articles_history_2026-01-01_to_2026-04-05
+
+# 3. 写入 Obsidian 的知乎收藏根目录分类文件夹
+python scripts/write_zhihu_history_to_obsidian.py \
+  /path/to/runtime/zhihu_articles_history_2026-01-01_to_2026-04-05 \
+  /path/to/ObsidianVault \
+  .
+```
+
+历史笔记会保留：
+
+```yaml
+interaction_action: "赞同了回答"
+interaction_time: 2026-03-20T10:17:57.235000+00:00
+interaction_date: 2026-03-20
+tags: [zhihu, 编程与开发, 赞同了回答]
+```
+
+历史列表中断时重新运行同一条命令即可续跑；加 `--fresh` 可忽略现有 checkpoint 重建。写入 Obsidian 时会扫描已有笔记的 `url` 并按 URL 更新，避免重复导入。
 
 ---
 

--- a/scripts/fetch_zhihu_batch.py
+++ b/scripts/fetch_zhihu_batch.py
@@ -18,6 +18,7 @@ import os
 import urllib.request
 import hashlib
 import random
+import subprocess
 
 sys.stdout.reconfigure(encoding='utf-8')
 
@@ -306,6 +307,29 @@ def save_progress(progress_file, progress):
     with open(progress_file, 'w', encoding='utf-8') as f:
         json.dump(progress, f, ensure_ascii=False, indent=2)
 
+def yaml_scalar(value):
+    """Return a simple YAML scalar that is safe enough for frontmatter."""
+    if value is None:
+        return '""'
+    if isinstance(value, (int, float)):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=False)
+
+def extra_frontmatter(item):
+    """Preserve optional metadata from generated list files."""
+    keys = [
+        'interaction_action',
+        'interaction_time',
+        'activity_id',
+        'liked_action',
+        'source_feed',
+    ]
+    lines = []
+    for key in keys:
+        if key in item and item.get(key) not in (None, ''):
+            lines.append(f"{key}: {yaml_scalar(item.get(key))}")
+    return '\n'.join(lines)
+
 def add_failure(progress, progress_file, url, reason, title='', index=0):
     """记录失败项到进度文件"""
     import time
@@ -320,6 +344,66 @@ def add_failure(progress, progress_file, url, reason, title='', index=0):
             'timestamp': int(time.time()),
         })
         save_progress(progress_file, progress)
+
+def int_arg(name, default):
+    """Parse a simple integer flag: --flag 3."""
+    if name not in sys.argv:
+        return default
+    try:
+        return int(sys.argv[sys.argv.index(name) + 1])
+    except Exception:
+        return default
+
+async def fetch_via_page_api(page, url):
+    """Fallback to Zhihu JSON APIs when DOM extraction returns too little text."""
+    answer_match = re.search(r'/answer/(\d+)', url)
+    article_match = re.search(r'zhuanlan\.zhihu\.com/p/(\d+)', url)
+    if answer_match:
+        api_url = (
+            f"https://www.zhihu.com/api/v4/answers/{answer_match.group(1)}"
+            "?include=content,excerpt,author,voteup_count,question"
+        )
+        kind = 'answer'
+    elif article_match:
+        api_url = f"https://zhuanlan.zhihu.com/api/articles/{article_match.group(1)}"
+        kind = 'article'
+    else:
+        return None
+
+    result = await page.evaluate(
+        '''async ({apiUrl, kind}) => {
+            try {
+                const response = await fetch(apiUrl, {credentials: 'include'});
+                const text = await response.text();
+                if (!response.ok) {
+                    return {ok: false, status: response.status, text: text.slice(0, 500)};
+                }
+                const data = JSON.parse(text);
+                let title = data.title || '';
+                if (!title && data.question) title = data.question.title || '';
+                const author = data.author ? (data.author.name || '') : '';
+                const html = data.content || data.detail || '';
+                const plain = html.replace(/<[^>]+>/g, '').trim();
+                return {ok: true, kind, title, author, html, text: plain};
+            } catch (error) {
+                return {ok: false, status: 0, text: String(error)};
+            }
+        }''',
+        {'apiUrl': api_url, 'kind': kind},
+    )
+    if result and result.get('ok') and len(result.get('text', '')) > 100:
+        return {
+            'title': result.get('title', ''),
+            'author': result.get('author', ''),
+            'html': result.get('html', ''),
+            'text': result.get('text', ''),
+            'source': f'api:{kind}',
+        }
+    if result and result.get('status') == 403:
+        return {'error': 'api_blocked_403'}
+    if result:
+        return {'error': f"api_failed:{result.get('status', 0)}"}
+    return None
 
 async def main():
     # 解析参数
@@ -350,12 +434,14 @@ async def main():
     
     items = collection.get('items', [])
     total = len(items)
+    original_total = total
     
     # 加载进度
     progress_file = os.path.join(output_dir, '_progress.json')
     progress = load_progress(progress_file)
     completed_urls = set(progress.get('completed', []))
     failed_urls = {f['url'] for f in progress.get('failed', [])}
+    auto_retry_max = 0 if '--no-auto-retry' in sys.argv else int_arg('--auto-retry', 3)
     
     # --no-interrupt 模式：不因连续失败中断
     no_interrupt = '--no-interrupt' in sys.argv
@@ -368,7 +454,16 @@ async def main():
     retry_failed = '--retry-failed' in sys.argv
     if retry_failed:
         print("[模式] 重试失败项")
-        # 清空 failed 列表，让脚本重新尝试
+        retry_urls = {f['url'] for f in progress.get('failed', [])}
+        if retry_urls:
+            items = [item for item in items if item.get('url', '') in retry_urls]
+            total = len(items)
+            print(f"[模式] 本次仅重试 {total} 个失败项")
+        else:
+            items = []
+            total = 0
+            print("[模式] 没有可重试的失败项")
+        # 清空 failed 列表，让本次重试重新记录仍失败的项
         progress['failed'] = []
         failed_urls = set()
         save_progress(progress_file, progress)
@@ -621,6 +716,12 @@ async def main():
                         # 保存当前进度后再退出
                         save_progress(progress_file, progress)
                         break
+                if 'unhuman' in page.url:
+                    should_stop = record_failure(url, 'safety_verification', title, i+1)
+                    fail += 1
+                    if should_stop:
+                        break
+                    continue
                 
                 # 滚动页面加载所有内容
                 await page.evaluate('window.scrollTo(0, document.body.scrollHeight)')
@@ -657,6 +758,16 @@ async def main():
                 
                 html_content = article_data.get('html', '')
                 text_content = article_data.get('text', '')
+                fallback_error = ''
+                if not (text_content and len(text_content) > 100):
+                    fallback_data = await fetch_via_page_api(page, url)
+                    if fallback_data and fallback_data.get('text') and len(fallback_data.get('text', '')) > 100:
+                        article_data = fallback_data
+                        html_content = article_data.get('html', '')
+                        text_content = article_data.get('text', '')
+                        print(f"  [API] DOM内容不足，使用 {fallback_data.get('source')} 回退")
+                    elif fallback_data and fallback_data.get('error'):
+                        fallback_error = fallback_data.get('error')
                 
                 if text_content and len(text_content) > 100:
                     # 转换为 Markdown 并下载图片
@@ -688,6 +799,7 @@ source: zhihu
 url: "{url}"
 voteup: {voteup}
 images: {len(images)}
+{extra_frontmatter(item)}
 ---
 
 # {final_title}
@@ -716,7 +828,8 @@ images: {len(images)}
                     save_progress(progress_file, progress)
                 else:
                     print(f"  [!] 内容为空或太短")
-                    should_stop = record_failure(url, 'content_empty', title, i+1)
+                    reason = f'content_empty:{fallback_error}' if fallback_error else 'content_empty'
+                    should_stop = record_failure(url, reason, title, i+1)
                     fail += 1
                     if should_stop:
                         break
@@ -732,6 +845,7 @@ images: {len(images)}
                 if should_stop:
                     break
         
+        flush_pending_failures()
         # 结束前保存最新 cookie
         await save_browser_cookies(context)
         await context.close()
@@ -739,12 +853,42 @@ images: {len(images)}
     print()
     print("=" * 60)
     print(f"完成! 成功: {success} | 失败: {fail} | 跳过: {skip}")
-    print(f"总进度: {len(completed_urls)}/{total} ({len(completed_urls)*100//total}%)")
+    denominator = original_total or total or 1
+    print(f"总进度: {len(completed_urls)}/{denominator} ({len(completed_urls)*100//denominator}%)")
     failed_count = len(progress.get('failed', []))
     if failed_count:
         print(f"已记录失败: {failed_count} 条（可用 --retry-failed 重试）")
     print("=" * 60)
 
+    if auto_retry_max > 0 and not retry_failed:
+        for attempt in range(1, auto_retry_max + 1):
+            latest = load_progress(progress_file)
+            remaining_failed = latest.get('failed', [])
+            if not remaining_failed:
+                break
+            print()
+            print("=" * 60)
+            print(f"自动重试失败项: 第 {attempt}/{auto_retry_max} 次，待重试 {len(remaining_failed)} 条")
+            print("=" * 60)
+            cmd = [
+                sys.executable,
+                os.path.abspath(__file__),
+                list_file,
+                output_dir,
+                images_dir,
+                '--retry-failed',
+                '--no-auto-retry',
+            ]
+            result = subprocess.run(cmd, cwd=os.getcwd(), env=os.environ.copy())
+            if result.returncode != 0:
+                print(f"[!] 自动重试进程退出码: {result.returncode}")
+                break
+        latest = load_progress(progress_file)
+        remaining_failed = latest.get('failed', [])
+        if remaining_failed:
+            print(f"自动重试后仍失败: {len(remaining_failed)} 条")
+        else:
+            print("自动重试完成：没有剩余失败项")
+
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/scripts/fetch_zhihu_history.py
+++ b/scripts/fetch_zhihu_history.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""
+Collect recent liked/collected Zhihu feed items from a profile activity page.
+
+The output JSON matches fetch_zhihu_batch.py's input shape, with extra
+interaction metadata preserved per item.
+
+Usage:
+  python fetch_zhihu_history.py <profile-url-or-slug> <cutoff-iso> [output-json] [--until <until-iso>]
+
+Example:
+  python fetch_zhihu_history.py duan-mu-yue-dao 2026-05-05T00:00:00+02:00
+"""
+
+import asyncio
+import datetime as dt
+import json
+import os
+import re
+import sys
+from urllib.parse import urlparse
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+try:
+    from playwright.async_api import async_playwright
+except ImportError:
+    print("请先安装 playwright: pip install playwright && playwright install chromium")
+    sys.exit(1)
+
+
+WORKSPACE = os.environ.get(
+    "OPENCLAW_WORKSPACE", os.path.join(os.path.expanduser("~"), ".openclaw", "workspace")
+)
+
+LIKED_OR_COLLECTED_PREFIXES = ("赞同了", "喜欢了", "收藏了")
+TARGET_TYPES = {"answer", "article"}
+
+
+def parse_slug(raw):
+    raw = raw.strip()
+    if raw.startswith("http://") or raw.startswith("https://"):
+        parts = [p for p in urlparse(raw).path.split("/") if p]
+        if "people" in parts:
+            idx = parts.index("people")
+            if idx + 1 < len(parts):
+                return parts[idx + 1]
+    return raw.rstrip("/")
+
+
+def parse_cutoff(raw):
+    value = raw.strip().replace(" ", "T")
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    parsed = dt.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        print("[!] cutoff has no timezone; assuming Europe/Stockholm")
+        from zoneinfo import ZoneInfo
+
+        parsed = parsed.replace(tzinfo=ZoneInfo("Europe/Stockholm"))
+    return parsed
+
+
+def optional_arg(name, default=None):
+    if name not in sys.argv:
+        return default
+    try:
+        return sys.argv[sys.argv.index(name) + 1]
+    except Exception:
+        return default
+
+
+def activity_ms(activity):
+    try:
+        return int(activity.get("id") or 0)
+    except Exception:
+        return 0
+
+
+def iso_from_ms(ms):
+    if not ms:
+        return ""
+    return dt.datetime.fromtimestamp(ms / 1000, dt.timezone.utc).isoformat()
+
+
+def web_url(target):
+    target_type = target.get("type")
+    if target_type == "article":
+        url = target.get("url") or ""
+        if "zhuanlan.zhihu.com/p/" in url:
+            return url.split("?")[0]
+        if target.get("id"):
+            return f"https://zhuanlan.zhihu.com/p/{target['id']}"
+    if target_type == "answer":
+        question = target.get("question") or {}
+        qid = question.get("id")
+        aid = target.get("id")
+        if qid and aid:
+            return f"https://www.zhihu.com/question/{qid}/answer/{aid}"
+    return None
+
+
+def item_from_activity(activity):
+    action = activity.get("action_text") or activity.get("verb") or activity.get("action") or ""
+    target = activity.get("target") or {}
+    target_type = target.get("type")
+    if target_type not in TARGET_TYPES:
+        return None
+    if not action.startswith(LIKED_OR_COLLECTED_PREFIXES):
+        return None
+
+    url = web_url(target)
+    if not url:
+        return None
+
+    if target_type == "answer":
+        title = (target.get("question") or {}).get("title") or f"answer_{target.get('id')}"
+    else:
+        title = target.get("title") or f"article_{target.get('id')}"
+
+    author = (target.get("author") or {}).get("name", "")
+    ms = activity_ms(activity)
+    return {
+        "url": url,
+        "title": title,
+        "author": author,
+        "voteup": target.get("voteup_count", 0),
+        "type": target_type,
+        "interaction_action": action,
+        "interaction_time": iso_from_ms(ms),
+        "activity_id": activity.get("id", ""),
+    }
+
+
+def state_path_for(output_json):
+    return f"{output_json}.state.json"
+
+
+def load_state(output_json):
+    state_path = state_path_for(output_json)
+    state = {}
+    if os.path.exists(state_path):
+        try:
+            with open(state_path, "r", encoding="utf-8") as f:
+                state = json.load(f)
+        except Exception:
+            state = {}
+    if not state and os.path.exists(output_json):
+        try:
+            with open(output_json, "r", encoding="utf-8") as f:
+                existing = json.load(f)
+            state = {"items": existing.get("items", [])}
+        except Exception:
+            state = {}
+    state.setdefault("items", [])
+    state.setdefault("seen_activity_urls", [])
+    state.setdefault("oldest_seen_ms", 0)
+    state.setdefault("completed", False)
+    return state
+
+
+def save_checkpoint(
+    output_json,
+    profile_url,
+    cutoff,
+    until,
+    items,
+    seen_activity_urls,
+    oldest_seen_ms,
+    completed=False,
+):
+    items.sort(key=lambda item: item.get("interaction_time", ""), reverse=True)
+    output = {
+        "total": len(items),
+        "source": profile_url,
+        "cutoff": cutoff.isoformat(),
+        "until": until.isoformat() if until else "",
+        "filter": "liked_or_collected_answers_and_articles",
+        "items": items,
+    }
+    with open(output_json, "w", encoding="utf-8") as f:
+        json.dump(output, f, ensure_ascii=False, indent=2)
+    state = {
+        "items": items,
+        "seen_activity_urls": sorted(seen_activity_urls),
+        "oldest_seen_ms": oldest_seen_ms,
+        "completed": completed,
+        "updated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+    }
+    with open(state_path_for(output_json), "w", encoding="utf-8") as f:
+        json.dump(state, f, ensure_ascii=False, indent=2)
+
+
+async def main():
+    if len(sys.argv) < 3:
+        print("用法: python fetch_zhihu_history.py <profile-url-or-slug> <cutoff-iso> [output-json]")
+        print("示例: python fetch_zhihu_history.py duan-mu-yue-dao 2026-05-05T00:00:00+02:00")
+        sys.exit(1)
+
+    slug = parse_slug(sys.argv[1])
+    cutoff = parse_cutoff(sys.argv[2])
+    cutoff_ms = int(cutoff.timestamp() * 1000)
+    until_raw = optional_arg("--until")
+    until = parse_cutoff(until_raw) if until_raw else None
+    until_ms = int(until.timestamp() * 1000) if until else None
+    output_json = (
+        sys.argv[3]
+        if len(sys.argv) >= 4 and not sys.argv[3].startswith("--")
+        else os.path.join(WORKSPACE, f"zhihu_people_{slug}_history_since_{cutoff.date()}.json")
+    )
+
+    os.makedirs(WORKSPACE, exist_ok=True)
+    profile_url = f"https://www.zhihu.com/people/{slug}"
+    print(f"profile: {profile_url}")
+    print(f"cutoff: {cutoff.isoformat()}")
+    if until:
+        print(f"until: {until.isoformat()}")
+
+    state = {} if "--fresh" in sys.argv else load_state(output_json)
+    items = state.get("items", [])
+    seen_urls = {item.get("url") for item in items if item.get("url")}
+    seen_activity_urls = set(state.get("seen_activity_urls", []))
+    oldest_seen_ms = int(state.get("oldest_seen_ms") or 0)
+    if state.get("completed"):
+        print(f"[resume] previous run was complete; refreshing from the first feed page")
+        seen_activity_urls = set()
+        oldest_seen_ms = 0
+    elif items or seen_activity_urls:
+        print(
+            f"[resume] loaded items={len(items)} feed_pages={len(seen_activity_urls)} "
+            f"oldest={iso_from_ms(oldest_seen_ms)}"
+        )
+    response_tasks = []
+    start_url = f"https://www.zhihu.com/api/v3/moments/{slug}/activities?limit=5&desktop=true&ws_qiangzhisafe=0"
+
+    async def process_payload(payload):
+        nonlocal oldest_seen_ms
+        activities = payload.get("data") or []
+        for activity in activities:
+            ms = activity_ms(activity)
+            if ms:
+                oldest_seen_ms = ms if not oldest_seen_ms else min(oldest_seen_ms, ms)
+            if until_ms and ms and ms >= until_ms:
+                continue
+            if ms and ms < cutoff_ms:
+                continue
+            item = item_from_activity(activity)
+            if not item or item["url"] in seen_urls:
+                continue
+            seen_urls.add(item["url"])
+            items.append(item)
+
+    async def on_response(response):
+        url = response.url
+        if "/api/v3/moments/" not in url or "/activities" not in url:
+            return
+        if url in seen_activity_urls:
+            return
+        seen_activity_urls.add(url)
+        try:
+            payload = await response.json()
+            await process_payload(payload)
+            print(
+                f"feed_pages={len(seen_activity_urls)} items={len(items)} "
+                f"oldest={iso_from_ms(oldest_seen_ms)}"
+            )
+            save_checkpoint(
+                output_json,
+                profile_url,
+                cutoff,
+                until,
+                items,
+                seen_activity_urls,
+                oldest_seen_ms,
+                completed=False,
+            )
+        except Exception as exc:
+            print(f"[!] failed to parse activity response: {exc}")
+
+    async with async_playwright() as p:
+        context = await p.chromium.launch_persistent_context(
+            os.path.join(WORKSPACE, "chrome_user_data"),
+            headless=True,
+            args=["--disable-blink-features=AutomationControlled"],
+            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            viewport={"width": 1440, "height": 900},
+        )
+        page = context.pages[0] if context.pages else await context.new_page()
+
+        def schedule_response(response):
+            response_tasks.append(asyncio.create_task(on_response(response)))
+
+        page.on("response", schedule_response)
+        await page.goto(profile_url, wait_until="domcontentloaded", timeout=30000)
+        await page.wait_for_timeout(3000)
+
+        active_fetch_done = False
+        next_url = start_url
+        for _ in range(300):
+            if oldest_seen_ms and oldest_seen_ms < cutoff_ms:
+                break
+            if next_url in seen_activity_urls:
+                break
+            payload = await page.evaluate(
+                """async (url) => {
+                    const response = await fetch(url, {credentials: 'include'});
+                    const text = await response.text();
+                    return {ok: response.ok, status: response.status, text};
+                }""",
+                next_url,
+            )
+            if not payload.get("ok"):
+                print(f"[FAIL] activity fetch failed: HTTP {payload.get('status')} {payload.get('text', '')[:200]}")
+                sys.exit(2)
+            data = json.loads(payload["text"])
+            seen_activity_urls.add(next_url)
+            await process_payload(data)
+            active_fetch_done = True
+            print(
+                f"feed_pages={len(seen_activity_urls)} items={len(items)} "
+                f"oldest={iso_from_ms(oldest_seen_ms)}"
+            )
+            save_checkpoint(
+                output_json,
+                profile_url,
+                cutoff,
+                until,
+                items,
+                seen_activity_urls,
+                oldest_seen_ms,
+                completed=False,
+            )
+            paging = data.get("paging") or {}
+            if paging.get("is_end"):
+                break
+            next_url = paging.get("next")
+            if not next_url:
+                break
+
+        stable_rounds = 0
+        last_page_count = 0
+        if not active_fetch_done:
+            for _ in range(120):
+                if oldest_seen_ms and oldest_seen_ms < cutoff_ms:
+                    break
+                await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+                await page.wait_for_timeout(1500)
+                if response_tasks:
+                    await asyncio.gather(*response_tasks, return_exceptions=True)
+                    response_tasks.clear()
+                page_count = len(seen_activity_urls)
+                if page_count == last_page_count:
+                    stable_rounds += 1
+                else:
+                    stable_rounds = 0
+                    last_page_count = page_count
+                if stable_rounds >= 8:
+                    break
+
+        if response_tasks:
+            await asyncio.gather(*response_tasks, return_exceptions=True)
+        await context.close()
+
+    if not seen_activity_urls:
+        print("[FAIL] no Zhihu activity feed pages were captured; profile may be on safety verification")
+        sys.exit(2)
+
+    save_checkpoint(
+        output_json,
+        profile_url,
+        cutoff,
+        until,
+        items,
+        seen_activity_urls,
+        oldest_seen_ms,
+        completed=True,
+    )
+
+    counts = {}
+    actions = {}
+    for item in items:
+        counts[item["type"]] = counts.get(item["type"], 0) + 1
+        actions[item["interaction_action"]] = actions.get(item["interaction_action"], 0) + 1
+    print(f"saved: {output_json}")
+    print(f"items: {len(items)}")
+    print(f"types: {counts}")
+    print(f"actions: {actions}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/write_zhihu_failures.py
+++ b/scripts/write_zhihu_failures.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Write a consolidated Obsidian note for failed Zhihu fetch items.
+
+Usage:
+  python write_zhihu_failures.py <vault-path> <label>:<progress-json> [...]
+"""
+
+import datetime
+import json
+import sys
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+
+def load_failed(label, path):
+    path = Path(path).expanduser()
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text(encoding="utf-8"))
+    rows = []
+    for item in data.get("failed", []):
+        rows.append(
+            {
+                "range": label,
+                "index": item.get("index", ""),
+                "title": item.get("title", ""),
+                "reason": item.get("reason", ""),
+                "url": item.get("url", ""),
+            }
+        )
+    return rows
+
+
+def escape_cell(value):
+    return str(value).replace("|", "\\|").replace("\n", " ").strip()
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("用法: python write_zhihu_failures.py <vault-path> <label>:<progress-json> [...]")
+        sys.exit(1)
+
+    vault = Path(sys.argv[1]).expanduser().resolve()
+    zhihu_dir = vault / "知乎收藏"
+    zhihu_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    seen = set()
+    for spec in sys.argv[2:]:
+        if ":" not in spec:
+            print(f"[!] skipping invalid spec: {spec}")
+            continue
+        label, path = spec.split(":", 1)
+        for row in load_failed(label, path):
+            url = row.get("url")
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            rows.append(row)
+
+    lines = [
+        "---",
+        'title: "知乎抓取失败项"',
+        'source: "zhihu"',
+        f"updated: {datetime.date.today().isoformat()}",
+        "tags: [zhihu, 抓取失败]",
+        "---",
+        "",
+        "# 知乎抓取失败项",
+        "",
+        "These items failed during body fetch and can be retried manually later.",
+        "",
+    ]
+    if rows:
+        lines.extend(["| Range | # | Title | Reason | URL |", "|---|---:|---|---|---|"])
+        for row in rows:
+            lines.append(
+                f"| {escape_cell(row['range'])} | {escape_cell(row['index'])} | "
+                f"{escape_cell(row['title'])} | {escape_cell(row['reason'])} | {escape_cell(row['url'])} |"
+            )
+    else:
+        lines.append("No failed items currently recorded.")
+
+    note = zhihu_dir / "抓取失败.md"
+    note.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"failed_items: {len(rows)}")
+    print(f"wrote: {note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/write_zhihu_history_to_obsidian.py
+++ b/scripts/write_zhihu_history_to_obsidian.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+Import fetched Zhihu history notes into an Obsidian all-history folder.
+
+Usage:
+  python write_zhihu_history_to_obsidian.py <article-dir> <vault-path> [folder-name]
+
+Use "." or omit folder-name to write under the Zhihu root category folders:
+  {Vault}/知乎收藏/{category}/...
+"""
+
+import json
+import os
+import re
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+CATEGORY_RULES = {
+    "AI与人工智能": [
+        "ai",
+        "人工智能",
+        "gpt",
+        "chatgpt",
+        "claude",
+        "大模型",
+        "llm",
+        "aigc",
+        "agent",
+        "vibe coding",
+    ],
+    "编程与开发": [
+        "python",
+        "java",
+        "javascript",
+        "typescript",
+        "c++",
+        "rust",
+        "golang",
+        "编程",
+        "代码",
+        "开发",
+        "框架",
+        "api",
+        "数据库",
+        "docker",
+        "git",
+        "linux",
+        "asio",
+        "networking",
+        "slam",
+    ],
+    "创业与商业": ["创业", "商业", "融资", "投资", "产品", "运营", "市场", "营销", "团队", "公司"],
+    "效率与工具": ["效率", "工具", "自动化", "工作流", "笔记", "obsidian", "notion", "netcat"],
+    "职场与成长": ["职场", "工作", "面试", "职业", "成长", "学习", "简历", "管理"],
+    "科技与互联网": ["科技", "互联网", "芯片", "区块链", "web3", "自动驾驶", "机器人"],
+    "产品与设计": ["产品", "设计", "ui", "ux", "交互", "用户体验", "figma"],
+    "生活杂谈": ["生活", "健康", "旅行", "电影", "读书", "文学", "红楼梦", "黛玉"],
+}
+
+
+def parse_frontmatter(path):
+    content = Path(path).read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {}, content
+    end = content.find("---", 3)
+    if end < 0:
+        return {}, content
+    raw = content[3:end].strip()
+    body = content[end + 3 :].strip()
+    meta = {}
+    for line in raw.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip()
+        try:
+            meta[key.strip()] = json.loads(value)
+        except Exception:
+            meta[key.strip()] = value.strip('"')
+    return meta, body
+
+
+def yaml_scalar(value):
+    if value is None:
+        return '""'
+    if isinstance(value, (int, float)):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def safe_filename(text):
+    text = re.sub(r'[\\/:*?"<>|]', "_", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:90] or "untitled"
+
+
+def sortable_stamp(value, fallback_index):
+    if not value:
+        return f"unknown_{fallback_index:04d}"
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        return parsed.strftime("%Y%m%d_%H%M%S")
+    except Exception:
+        return re.sub(r"[^0-9A-Za-z]+", "_", str(value)).strip("_")[:32]
+
+
+def interaction_date(value):
+    if not value:
+        return ""
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        return parsed.date().isoformat()
+    except Exception:
+        return ""
+
+
+def classify_item(title, body):
+    text = f"{title} {body[:1500]}".lower()
+    scores = {}
+    for category, keywords in CATEGORY_RULES.items():
+        score = sum(1 for keyword in keywords if keyword.lower() in text)
+        if score:
+            scores[category] = score
+    if scores:
+        return max(scores, key=scores.get)
+    if any(mark in title for mark in ["?", "？", "如何", "怎么", "为什么", "是什么"]):
+        return "问答与思考"
+    return "未分类"
+
+
+def rewrite_image_links(body, note_dir, zhihu_dir):
+    image_dir = zhihu_dir / "images"
+
+    def replace(match):
+        alt = match.group(1)
+        target = match.group(2)
+        if re.match(r"https?://", target):
+            return match.group(0)
+        relative = os.path.relpath(image_dir / Path(target).name, note_dir)
+        return f"![{alt}]({relative})"
+
+    return re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", replace, body)
+
+
+def sync_images(source_dir, vault_zhihu_dir):
+    source_images = Path(source_dir) / "images"
+    if not source_images.exists():
+        return 0
+    target_images = Path(vault_zhihu_dir) / "images"
+    target_images.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for src in source_images.iterdir():
+        if not src.is_file():
+            continue
+        dst = target_images / src.name
+        if not dst.exists():
+            shutil.copy2(src, dst)
+            copied += 1
+    return copied
+
+
+def build_url_index(history_dir):
+    """Map existing note source URLs to note paths for repeat-safe imports."""
+    index = {}
+    if not history_dir.exists():
+        return index
+    for path in history_dir.rglob("*.md"):
+        meta, _ = parse_frontmatter(path)
+        url = meta.get("url")
+        if url and url not in index:
+            index[url] = path
+    return index
+
+
+def unique_path(path):
+    if not path.exists():
+        return path
+    stem = path.stem
+    suffix = path.suffix
+    for i in range(2, 1000):
+        candidate = path.with_name(f"{stem}_{i}{suffix}")
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError(f"Unable to find unique filename for {path}")
+
+
+def resolve_history_root(zhihu_dir, folder_name):
+    if folder_name in ("", ".", "root", "知乎收藏"):
+        return zhihu_dir
+    return zhihu_dir / folder_name
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("用法: python write_zhihu_history_to_obsidian.py <article-dir> <vault-path> [folder-name]")
+        sys.exit(1)
+
+    source_dir = Path(sys.argv[1]).expanduser().resolve()
+    vault_path = Path(sys.argv[2]).expanduser().resolve()
+    folder_name = sys.argv[3] if len(sys.argv) >= 4 else "."
+
+    if not source_dir.exists():
+        print(f"article dir not found: {source_dir}")
+        sys.exit(1)
+    if not vault_path.exists():
+        print(f"vault path not found: {vault_path}")
+        sys.exit(1)
+
+    zhihu_dir = vault_path / "知乎收藏"
+    history_dir = resolve_history_root(zhihu_dir, folder_name)
+    history_dir.mkdir(parents=True, exist_ok=True)
+    url_index = build_url_index(history_dir)
+
+    md_files = sorted(p for p in source_dir.iterdir() if p.suffix == ".md" and not p.name.startswith("_"))
+    written = 0
+    updated = 0
+    skipped = 0
+    for index, path in enumerate(md_files, 1):
+        meta, body = parse_frontmatter(path)
+        title = meta.get("title") or path.stem
+        url = meta.get("url")
+        category = meta.get("category") or classify_item(title, body)
+        filename = f"{safe_filename(title)}.md"
+        dest_dir = history_dir / category
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        existing_dest = url_index.get(url) if url else None
+        if existing_dest:
+            dest = existing_dest
+            if dest.parent != dest_dir:
+                candidate = unique_path(dest_dir / filename)
+                dest.rename(candidate)
+                dest = candidate
+                url_index[url] = dest
+        else:
+            dest = unique_path(dest_dir / filename)
+
+        ordered_keys = [
+            "title",
+            "author",
+            "source",
+            "url",
+            "type",
+            "category",
+            "interaction_action",
+            "interaction_time",
+            "interaction_date",
+            "activity_id",
+            "voteup",
+            "images",
+        ]
+        meta["category"] = category
+        meta["interaction_date"] = interaction_date(meta.get("interaction_time"))
+        frontmatter = []
+        for key in ordered_keys:
+            if key in meta and meta.get(key) not in (None, ""):
+                if key in ("interaction_time", "interaction_date"):
+                    frontmatter.append(f"{key}: {meta.get(key)}")
+                else:
+                    frontmatter.append(f"{key}: {yaml_scalar(meta.get(key))}")
+        frontmatter.append(f"imported: {datetime.now().strftime('%Y-%m-%d')}")
+        frontmatter.append(
+            f"tags: [zhihu, {category}, {meta.get('interaction_action', 'unknown')}]"
+        )
+
+        output = (
+            "---\n"
+            + "\n".join(frontmatter)
+            + "\n---\n\n"
+            + rewrite_image_links(body, dest_dir, zhihu_dir).strip()
+            + "\n"
+        )
+        dest.write_text(output, encoding="utf-8")
+        if existing_dest:
+            updated += 1
+        else:
+            written += 1
+            if url:
+                url_index[url] = dest
+
+    copied_images = sync_images(source_dir, zhihu_dir)
+    print(f"source: {source_dir}")
+    print(f"destination: {history_dir}")
+    print(f"written: {written}")
+    print(f"updated: {updated}")
+    print(f"skipped: {skipped}")
+    print(f"new_images_copied: {copied_images}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add profile activity history collection for liked/collected answers and articles with cutoff/--until time ranges and checkpoint resume
- preserve interaction metadata and import history notes into Obsidian category folders with URL-based dedupe
- add failed-item tracking note generation and improve batch fetching with auto-retry plus API fallback for short DOM content
- document the new history workflow in README and SKILL.md

## Verification
- ran Python syntax checks with py_compile for the new/changed scripts
- exercised the workflow locally against Zhihu history ranges and Obsidian import
- verified URL dedupe by rerunning imports; duplicate URL count stayed at 0